### PR TITLE
Adição de endpoint getById à classe TransactionType

### DIFF
--- a/postman/Acelera_TCC_Grupo03_Postman_TransactionType.json
+++ b/postman/Acelera_TCC_Grupo03_Postman_TransactionType.json
@@ -25,6 +25,26 @@
 			"response": []
 		},
 		{
+			"name": "GET Transaction Type By Id",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8080/transaction-type/6",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"transaction-type",
+						"6"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "POST Transaction Type",
 			"request": {
 				"method": "POST",

--- a/src/main/java/com/acelera/tcc/group03/controllers/TransactionTypeController.java
+++ b/src/main/java/com/acelera/tcc/group03/controllers/TransactionTypeController.java
@@ -29,6 +29,11 @@ public class TransactionTypeController {
     	return ResponseEntity.ok(this.service.getAll());
     }
     
+    @GetMapping ("/{id}")
+    public ResponseEntity<TransactionType> getById(@PathVariable("id") Long id) {
+    	return ResponseEntity.ok(this.service.getById(id));
+    }
+    
     @PostMapping
     public String create(@RequestBody TransactionType transactionType) {
     	return this.service.create(transactionType).toString();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,6 @@ spring.datasource.username=root
 spring.datasource.password=secretapacas
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
 
 #logging.level.root=debug


### PR DESCRIPTION
Incluído o endpoint 'getById' à classe TransactionTypeController, e modificado o 'application.properties' para suportar a serialização de atributos de classe vazios.