### PR TITLE
Retirado construtor não-default da classe TransactinChannel, ajustada…

### DIFF
--- a/src/main/java/com/acelera/tcc/group03/domains/TransactionChannel.java
+++ b/src/main/java/com/acelera/tcc/group03/domains/TransactionChannel.java
@@ -26,11 +26,7 @@ public class TransactionChannel implements BaseEntity {
 	@OneToMany (mappedBy = "transactionChannel")
 	@JsonIgnoreProperties("transactionChannel")
 	private List<TransactionAccount> transactionAccounts;
-
-	public TransactionChannel(String name) {
-		this.name = name;
-	}
-
+	
 	@Override
 	public Long getId() {
 		return this.id;

--- a/src/main/java/com/acelera/tcc/group03/exceptions/CustomerAccountInsufficientFundsForWithdraw.java
+++ b/src/main/java/com/acelera/tcc/group03/exceptions/CustomerAccountInsufficientFundsForWithdraw.java
@@ -2,4 +2,8 @@ package com.acelera.tcc.group03.exceptions;
 
 public class CustomerAccountInsufficientFundsForWithdraw extends RuntimeException {
 	private static final long serialVersionUID = 1L;
+	
+	public CustomerAccountInsufficientFundsForWithdraw(String errorMessage) {
+		super(errorMessage);
+	}
 }

--- a/src/main/java/com/acelera/tcc/group03/exceptions/TransactionChannelNotFound.java
+++ b/src/main/java/com/acelera/tcc/group03/exceptions/TransactionChannelNotFound.java
@@ -1,5 +1,9 @@
 package com.acelera.tcc.group03.exceptions;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus (value = HttpStatus.BAD_REQUEST, reason = "Transaction Channel not found")
 public class TransactionChannelNotFound extends RuntimeException {
 	private static final long serialVersionUID = 1L;
 	

--- a/src/test/java/com/acelera/tcc/group03/controllers/TransactionChannelControllerTest.java
+++ b/src/test/java/com/acelera/tcc/group03/controllers/TransactionChannelControllerTest.java
@@ -1,40 +1,40 @@
 package com.acelera.tcc.group03.controllers;
 
-import com.acelera.tcc.group03.domains.Customer;
-import com.acelera.tcc.group03.domains.CustomerType;
-import com.acelera.tcc.group03.domains.TransactionChannel;
-import com.acelera.tcc.group03.services.TransactionChannelService;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.acelera.tcc.group03.domains.TransactionChannel;
+import com.acelera.tcc.group03.services.TransactionChannelService;
 
 public class TransactionChannelControllerTest {
     private TransactionChannelService transactionChannelService = Mockito.mock(TransactionChannelService.class);
-
+    
     @Test
     void shouldReturnStatus200WhenGetAllTransactionChannels(){
-        TransactionChannel transactionChannel = new TransactionChannel("Test");
-
+        TransactionChannel transactionChannel = new TransactionChannel();
+        transactionChannel.setName("Test");
+        
         Mockito.when(transactionChannelService.getAll()).thenReturn(Collections.singletonList(transactionChannel));
-
+        
         TransactionChannelController transactionChannelController = new TransactionChannelController(transactionChannelService);
         ResponseEntity<List<TransactionChannel>> actual = transactionChannelController.getAll();
-
+        
         assertEquals(actual, ResponseEntity.status(HttpStatus.OK).body(Collections.singletonList(transactionChannel)));
     }
-
-
+    
     @Test
     void shouldReturnStatus200WhenGetTransactionChannelById(){
         Long transactionChannelId = 1L;
-        TransactionChannel transactionChannel = new TransactionChannel("Test");
+        TransactionChannel transactionChannel = new TransactionChannel();
+        transactionChannel.setName("Test");
         Mockito.when(transactionChannelService.getById(transactionChannelId)).thenReturn(Optional.of(transactionChannel));
 
         TransactionChannelController transactionChannelController = new TransactionChannelController(transactionChannelService);
@@ -42,32 +42,20 @@ public class TransactionChannelControllerTest {
 
         assertEquals(actual, ResponseEntity.status(HttpStatus.OK).body(Optional.of(transactionChannel)));
     }
-
+    
     @Test
-    void shouldReturn200WhenDeleteTransactionChannel(){
+    void shouldReturn200WhenDeleteTransactionChannel() {
         Long transactionChannelId = 1L;
-        TransactionChannel transactionChannel = new TransactionChannel("Test");
+        TransactionChannel transactionChannel = new TransactionChannel();
+        transactionChannel.setName("Test");
         transactionChannelService.create(transactionChannel);
-
+        
         Mockito.when(transactionChannelService.getById(transactionChannelId)).thenReturn(Optional.of(transactionChannel));
         transactionChannelService.delete(transactionChannelId);
-
+        
         TransactionChannelController transactionChannelController = new TransactionChannelController(transactionChannelService);
         ResponseEntity<Object> actual = transactionChannelController.delete(transactionChannelId);
-
+        
         assertEquals(actual, ResponseEntity.status(HttpStatus.OK).build());
     }
-
-    /*
-    @Test
-    void shouldReturn201WhenCreateNewTransactionChannel(){
-        TransactionChannel transactionChannel = new TransactionChannel("Test");
-        Mockito.when(transactionChannelService.create(transactionChannel)).thenReturn(transactionChannel);
-
-        TransactionChannelController transactionChannelController = new TransactionChannelController(transactionChannelService);
-        ResponseEntity<TransactionChannel> actual = transactionChannelController.create(transactionChannel);
-
-        assertEquals(actual, ResponseEntity.status(HttpStatus.NO_CONTENT).build());
-    }
-    */
 }

--- a/src/test/java/com/acelera/tcc/group03/services/TransactionChannelServiceTests.java
+++ b/src/test/java/com/acelera/tcc/group03/services/TransactionChannelServiceTests.java
@@ -14,33 +14,32 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 public class TransactionChannelServiceTests {
-
     @Mock
     private TransactionChannelRepository transactionChannelRepository;
-
+    
     @InjectMocks
     private TransactionChannelService transactionChannelService;
-
+    
     @Test
     void shouldSaveWithSuccessTransactionChannel(){
-        TransactionChannel expected = new TransactionChannel("Test");
-
+        TransactionChannel expected = new TransactionChannel();
+        expected.setName("Test");
+        
         Mockito.when(transactionChannelRepository.save(expected)).thenReturn(expected);
-
+        
         TransactionChannel actual = transactionChannelService.create(expected);
-
+        
         assertEquals(expected, actual);
         Mockito.verify(transactionChannelRepository, Mockito.times(1)).save(expected);
     }
-
+    
     @Test
     void shouldFailToSaveTransactionChannelWithNoName(){
-        TransactionChannel expected = new TransactionChannel(null);
+        TransactionChannel expected = new TransactionChannel();
 
         Assertions.assertThrows(NullPointerException.class, () -> {
             transactionChannelService.create(expected);
         });
         Mockito.verifyNoInteractions(transactionChannelRepository);
     }
-
 }


### PR DESCRIPTION
…s as 2 respectivas classes de teste e configuradas as mensagens de erro das exceções (ainda retornam Erro 500 mas pelo menos com mensagem bem contextualizada do erro ocorrido, via construtor das exceções).